### PR TITLE
Fix the markup for nested lists

### DIFF
--- a/Advanced-HTTP-en.md
+++ b/Advanced-HTTP-en.md
@@ -175,23 +175,23 @@ To summarize the previous section, the interface provided by PHP suffers from
 the following limitations:
 
 1. `$ _REQUEST`:
-  1. mixing different sources contexts, should never be used.
+    1. mixing different sources contexts, should never be used.
 2. `$_SERVER`:
-  1. alteration of particular characters in headers names,
-  2. name collision for repeated headers,
-  3. web server dependency to get request context via environment variables.
+    1. alteration of particular characters in headers names,
+    2. name collision for repeated headers,
+    3. web server dependency to get request context via environment variables.
 3. `$_GET`, `$_COOKIE`, `$_POST`, `$_FILES`:
-  1. alteration of particular characters in keys names,
-  2. name collision for multi-valued keys,
-  3. name collision created by the bracketed syntax and by items 2.1 and 3.1,
-  4. complexity introduced by the bracketed syntax.
+    1. alteration of particular characters in keys names,
+    2. name collision for multi-valued keys,
+    3. name collision created by the bracketed syntax and by items 2.1 and 3.1,
+    4. complexity introduced by the bracketed syntax.
 4. Access to raw data:
-  1. no method is referenced to access the raw HTTP headers,
-    but `getallheaders()` can help when available,
-  2. the input to `$_GET` and `$_COOKIE` are in `$_SERVER`,
-  3. `php://stdin` should allow access to the body of the request, but only when
-    the `enable_post_data_reading` ini setting is set to off or for contents
-    other than *multipart/form-data*.
+    1. no method is referenced to access the raw HTTP headers,
+        but `getallheaders()` can help when available,
+    2. the input to `$_GET` and `$_COOKIE` are in `$_SERVER`,
+    3. `php://stdin` should allow access to the body of the request, but only when
+        the `enable_post_data_reading` ini setting is set to off or for contents
+        other than *multipart/form-data*.
 
 Destroying `$_REQUEST` as soon as possible to avoid any temptation to use it
 solves item 1.1. Anyway, its portability is limited by *php.ini*.

--- a/Advanced-HTTP-fr.md
+++ b/Advanced-HTTP-fr.md
@@ -188,24 +188,24 @@ Pour résumer la section précédente, l'interface fournie par PHP présente les
 défauts suivants :
 
 1. `$_REQUEST` :
-  1. mélange contextes sources différents, ne devrait jamais être utilisé.
+    1. mélange contextes sources différents, ne devrait jamais être utilisé.
 2. `$_SERVER` :
-  1. majuscules et suppression de caractères particuliers du nom des entêtes,
-  2. collision de noms pour les entêtes répétées,
-  3. dépendance sur le serveur web pour transmettre le contexte de la requête
-    via les variables d'environnement.
+    1. majuscules et suppression de caractères particuliers du nom des entêtes,
+    2. collision de noms pour les entêtes répétées,
+    3. dépendance sur le serveur web pour transmettre le contexte de la requête
+        via les variables d'environnement.
 3. `$_GET`, `$_COOKIE`, `$_POST`, `$_FILES` :
-  1. altération de caractères particuliers du nom des clefs,
-  2. collision de noms pour les clefs à valeurs multiples,
-  3. collision créée par la syntaxe à crochets et par les points 2.1 et 3.1,
-  4. complexité apportée par la syntaxe à crochets.
+    1. altération de caractères particuliers du nom des clefs,
+    2. collision de noms pour les clefs à valeurs multiples,
+    3. collision créée par la syntaxe à crochets et par les points 2.1 et 3.1,
+    4. complexité apportée par la syntaxe à crochets.
 4. Accès aux données brutes :
-  1. aucune méthode n'est référencée pour accéder aux entêtes HTTP brutes, sauf
+    1. aucune méthode n'est référencée pour accéder aux entêtes HTTP brutes, sauf
     partiellement via `getallheader()` lorsque la fonction est disponible,
-  2. les données qui alimentent `$_GET` et `$_COOKIE` sont dans `$_SERVER`,
-  3. `php://stdin` devrait permettre d'accéder au corps de la requête, mais
-    uniquement pour les contenus autres que *multipart/form-data* ou lorsque le
-    paramètre ini `enable_post_data_reading` a été désactivé.
+    2. les données qui alimentent `$_GET` et `$_COOKIE` sont dans `$_SERVER`,
+    3. `php://stdin` devrait permettre d'accéder au corps de la requête, mais
+        uniquement pour les contenus autres que *multipart/form-data* ou lorsque le
+        paramètre ini `enable_post_data_reading` a été désactivé.
 
 Le point 1.1 est soluble de façon trivial en détruisant la variable le plus tôt
 possible pour éviter toute tentation de s'en servir. De toute façon, la


### PR DESCRIPTION
Nested lists require at least 4 spaces of indentation in CommonMark (and so in GFM). Using 2 spaces will put all items in the same list, which breaks the numbers used to reference them later when rendering the markdown.